### PR TITLE
Adding further handling to double up inline markup when preceded or foll...

### DIFF
--- a/d2a.xsl
+++ b/d2a.xsl
@@ -505,9 +505,8 @@ ____
 
 <xsl:template match="emphasis[@role='bold']">*<xsl:apply-templates />*</xsl:template>
 
-<xsl:template match="filename">_<xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if><xsl:apply-templates/><xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if>_<xsl:if test="not(following-sibling::node()[1][self::userinput]) and matches(following-sibling::node()[1], '^[a-zA-Z]')"><xsl:text> </xsl:text></xsl:if></xsl:template>
-  <!-- Normalize-space() on text node below includes extra handling for child elements of filename, to add needed spaces back
-        in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
+  <xsl:template match="filename">_<xsl:if test="(preceding-sibling::text()[matches(., '\S$')]) or (following-sibling::text()[1][matches(., '^\S.*?') and not(matches(., '^\..*?')) and not(matches(., '^,.*?'))])">_</xsl:if><xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if><xsl:apply-templates/><xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if>_<xsl:if test="(preceding-sibling::text()[matches(., '\S$')]) or (following-sibling::text()[1][matches(., '^\S.*?') and not(matches(., '^\..*?')) and not(matches(., '^,.*?'))])">_</xsl:if><xsl:if test="not(following-sibling::node()[1][self::userinput]) and matches(following-sibling::node()[1], '^[a-zA-Z]')"><xsl:text> </xsl:text></xsl:if></xsl:template>
+  <!-- Normalize-space() on text node below includes extra handling for child elements of filename, to add needed spaces back in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
   <xsl:template match="filename/text()">
     <xsl:if test="preceding-sibling::* and (starts-with(.,' ') or starts-with(.,'&#10;'))">
       <xsl:text> </xsl:text>
@@ -518,9 +517,8 @@ ____
     </xsl:if>
   </xsl:template>
 
-  <xsl:template match="emphasis">_<xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if><xsl:apply-templates/><xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if>_<xsl:if test="not(following-sibling::node()[1][self::userinput]) and not(following-sibling::node()[1][self::indexterm]) and matches(following-sibling::node()[1], '^[a-zA-Z]')"><xsl:text> </xsl:text></xsl:if></xsl:template>
-  <!-- Normalize-space() on text node below includes extra handling for child elements of emphasis, to add needed spaces back
-        in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
+  <xsl:template match="emphasis">_<xsl:if test="(preceding-sibling::text()[matches(., '\S$')]) or (following-sibling::text()[1][matches(., '^\S.*?') and not(matches(., '^\..*?')) and not(matches(., '^,.*?'))])">_</xsl:if><xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if><xsl:apply-templates/><xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if>_<xsl:if test="(preceding-sibling::text()[matches(., '\S$')]) or (following-sibling::text()[1][matches(., '^\S.*?') and not(matches(., '^\..*?')) and not(matches(., '^,.*?'))])">_</xsl:if><xsl:if test="not(following-sibling::node()[1][self::userinput]) and not(following-sibling::node()[1][self::indexterm]) and matches(following-sibling::node()[1], '^[a-zA-Z]')"><xsl:text> </xsl:text></xsl:if></xsl:template>
+  <!-- Normalize-space() on text node below includes extra handling for child elements of emphasis, to add needed spaces back in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
   <xsl:template match="emphasis/text()">
     <xsl:if test="preceding-sibling::* and (starts-with(.,' ') or starts-with(.,'&#10;'))">
       <xsl:text> </xsl:text>
@@ -531,9 +529,8 @@ ____
     </xsl:if>
   </xsl:template>
 
-<xsl:template match="command">_<xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if><xsl:apply-templates/><xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if>_<xsl:if test="not(following-sibling::node()[1][self::userinput]) and matches(following-sibling::node()[1], '^[a-zA-Z]')"><xsl:text> </xsl:text></xsl:if></xsl:template>
-  <!-- Normalize-space() on text node below includes extra handling for child elements of command, to add needed spaces back
-        in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
+  <xsl:template match="command">_<xsl:if test="(preceding-sibling::text()[matches(., '\S$')]) or (following-sibling::text()[1][matches(., '^\S.*?') and not(matches(., '^\..*?')) and not(matches(., '^,.*?'))])">_</xsl:if><xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if><xsl:apply-templates/><xsl:if test="contains(., '~') or contains(., '_')">$$</xsl:if>_<xsl:if test="(preceding-sibling::text()[matches(., '\S$')]) or (following-sibling::text()[1][matches(., '^\S.*?') and not(matches(., '^\..*?')) and not(matches(., '^,.*?'))])">_</xsl:if><xsl:if test="not(following-sibling::node()[1][self::userinput]) and matches(following-sibling::node()[1], '^[a-zA-Z]')"><xsl:text> </xsl:text></xsl:if></xsl:template>
+  <!-- Normalize-space() on text node below includes extra handling for child elements of command, to add needed spaces back in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
   <xsl:template match="command/text()">
     <xsl:if test="preceding-sibling::* and (starts-with(.,' ') or starts-with(.,'&#10;'))">
       <xsl:text> </xsl:text>
@@ -544,12 +541,11 @@ ____
     </xsl:if>
   </xsl:template>
 
-  <xsl:template match="literal"><xsl:if test="preceding-sibling::node()[1][self::replaceable] or following-sibling::node()[1][self::replaceable] or following-sibling::node()[1][self::emphasis] or substring(following-sibling::node()[1],1,1) = 's' or substring(following-sibling::node()[1],1,1) = '’'">+</xsl:if>+<xsl:if test='contains(., "+") or contains(., "&apos;")'>$$</xsl:if><xsl:apply-templates/><xsl:if test='contains(., "+") or contains(., "&apos;")'>$$</xsl:if>+<xsl:if test="preceding-sibling::node()[1][self::replaceable] or following-sibling::node()[1][self::replaceable] or following-sibling::node()[1][self::emphasis] or substring(following-sibling::node()[1],1,1) = 's' or substring(following-sibling::node()[1],1,1) = '’'">+</xsl:if></xsl:template>
+  <xsl:template match="literal"><xsl:if test="preceding-sibling::node()[1][self::replaceable] or following-sibling::node()[1][self::replaceable] or following-sibling::node()[1][self::emphasis] or preceding-sibling::text()[matches(., '\S$')] or (following-sibling::text()[1][matches(., '^\S.*?') and not(matches(., '^\..*?')) and not(matches(., '^,.*?'))])">+</xsl:if>+<xsl:if test='contains(., "+") or contains(., "&apos;")'>$$</xsl:if><xsl:apply-templates/><xsl:if test='contains(., "+") or contains(., "&apos;")'>$$</xsl:if>+<xsl:if test="preceding-sibling::node()[1][self::replaceable] or following-sibling::node()[1][self::replaceable] or following-sibling::node()[1][self::emphasis] or preceding-sibling::text()[matches(., '\S$')] or (following-sibling::text()[1][matches(., '^\S.*?') and not(matches(., '^\..*?')) and not(matches(., '^,.*?'))])">+</xsl:if></xsl:template>
   <xsl:template match="literal/text()"><xsl:value-of select="replace(., '([\[\]\*\^~])', '\\$1', 'm')"></xsl:value-of></xsl:template>
   
 <xsl:template match="userinput">**`<xsl:apply-templates />`**</xsl:template>
-  <!-- Normalize-space() on text node below includes extra handling for child elements of userinput, to add needed spaces back
-        in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
+  <!-- Normalize-space() on text node below includes extra handling for child elements of userinput, to add needed spaces back in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
   <xsl:template match="userinput/text()">
     <xsl:if test="preceding-sibling::* and (starts-with(.,' ') or starts-with(.,'&#10;'))">
       <xsl:text> </xsl:text>
@@ -561,8 +557,7 @@ ____
   </xsl:template>
 
 <xsl:template match="replaceable">_++<xsl:apply-templates />++_</xsl:template>
-  <!-- Normalize-space() on text node below includes extra handling for child elements of replaceable, to add needed spaces back
-        in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
+  <!-- Normalize-space() on text node below includes extra handling for child elements of replaceable, to add needed spaces back in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
   <xsl:template match="replaceable/text()">
     <xsl:if test="preceding-sibling::* and (starts-with(.,' ') or starts-with(.,'&#10;'))">
       <xsl:text> </xsl:text>
@@ -574,8 +569,7 @@ ____
   </xsl:template>
   
 <xsl:template match="superscript">^<xsl:apply-templates />^</xsl:template>
-  <!-- Normalize-space() on text node below includes extra handling for child elements of superscript, to add needed spaces back
-        in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
+  <!-- Normalize-space() on text node below includes extra handling for child elements of superscript, to add needed spaces back in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
   <xsl:template match="superscript/text()">
     <xsl:if test="preceding-sibling::* and (starts-with(.,' ') or starts-with(.,'&#10;'))">
       <xsl:text> </xsl:text>
@@ -587,8 +581,7 @@ ____
   </xsl:template>
 
 <xsl:template match="subscript">~<xsl:apply-templates />~</xsl:template>
-  <!-- Normalize-space() on text node below includes extra handling for child elements of subscript, to add needed spaces back
-        in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
+  <!-- Normalize-space() on text node below includes extra handling for child elements of subscript, to add needed spaces back in. (They're removed by normalize-space(), which normalizes the two text nodes separately.) -->
   <xsl:template match="subscript/text()">
     <xsl:if test="preceding-sibling::* and (starts-with(.,' ') or starts-with(.,'&#10;'))">
       <xsl:text> </xsl:text>


### PR DESCRIPTION
...owed by non-whitespace character. The preceding test sometimes matches more inlines than necessary for doubling up, but this shouldnt cause any problems, as its still valid markup. 
