### PR TITLE
fixed bug in variablist template

### DIFF
--- a/d2a.xsl
+++ b/d2a.xsl
@@ -559,8 +559,9 @@ ____
 <xsl:call-template name="process-id"/>
 [<xsl:value-of select="upper-case(name())"/>]
 <xsl:apply-templates select="." mode="title"/>====
-<xsl:apply-templates select="node()[not(self::title)]"/>====
-<!-- <xsl:value-of select="util:carriage-returns(2)"/> -->
+<xsl:apply-templates select="node()[not(self::title)]"/>
+====
+<xsl:value-of select="util:carriage-returns(2)"/>
 </xsl:template>
 
 <xsl:template match="term"><xsl:apply-templates select="node()"/>:: </xsl:template>
@@ -729,7 +730,6 @@ ____
   <xsl:text>+</xsl:text><xsl:value-of select="util:carriage-returns(1)"/>
 </xsl:if>
 <xsl:call-template name="process-id"/>
-<xsl:text>&#10;</xsl:text>
 <xsl:text>.</xsl:text><xsl:apply-templates select="title"/>
 image::<xsl:value-of select="mediaobject/imageobject[@role='web']/imagedata/@fileref"/>[]
 <xsl:choose>
@@ -741,7 +741,6 @@ image::<xsl:value-of select="mediaobject/imageobject[@role='web']/imagedata/@fil
 <xsl:template match="informalfigure">
 <xsl:value-of select="util:carriage-returns(1)"/>
 <xsl:call-template name="process-id"/>
-<xsl:text>&#10;</xsl:text>
 image::<xsl:value-of select="mediaobject/imageobject[@role='web']/imagedata/@fileref"/>[]
 <xsl:value-of select="util:carriage-returns(1)"/>
 </xsl:template>
@@ -1263,7 +1262,7 @@ pass:[<xsl:copy-of select="."/>]
   <xsl:if test="@id">
     <xsl:text xml:space="preserve">[[</xsl:text>
     <xsl:value-of select="@id"/>
-    <xsl:text xml:space="preserve">]]</xsl:text>
+    <xsl:text xml:space="preserve">]]&#10;</xsl:text>
   </xsl:if>
 </xsl:template>
 

--- a/d2a.xsl
+++ b/d2a.xsl
@@ -76,6 +76,7 @@
   <xsl:variable name="part_content">
     <!-- Title and partintro (if present) -->
     <xsl:call-template name="process-id"/>
+    <xsl:text>&#10;</xsl:text>
     <xsl:text xml:space="preserve">= </xsl:text>
     <xsl:apply-templates select="title"/>
     <xsl:value-of select="util:carriage-returns(2)"/>
@@ -260,7 +261,7 @@
 </xsl:template>
   
 <!-- Special handling for text inside code block that will be converted as Asciidoc, 
-      to make sure special characters are not escaped. -->
+      to make sure special characters are not escaped.-->
 <xsl:template match="text()" mode="code">
   <xsl:value-of select="." disable-output-escaping="yes"></xsl:value-of>
 </xsl:template>
@@ -558,9 +559,8 @@ ____
 <xsl:call-template name="process-id"/>
 [<xsl:value-of select="upper-case(name())"/>]
 <xsl:apply-templates select="." mode="title"/>====
-<xsl:apply-templates select="node()[not(self::title)]"/>
-====
-<xsl:value-of select="util:carriage-returns(2)"/>
+<xsl:apply-templates select="node()[not(self::title)]"/>====
+<!-- <xsl:value-of select="util:carriage-returns(2)"/> -->
 </xsl:template>
 
 <xsl:template match="term"><xsl:apply-templates select="node()"/>:: </xsl:template>
@@ -676,7 +676,7 @@ ____
 <xsl:template match="variablelist">
   <xsl:choose>
     <!-- When variablelist has a varlistentry with more than one term, or a nested variablelist, output as passthrough -->
-    <xsl:when test="varlistentry/term[2] | //variablelist">
+    <xsl:when test="./varlistentry/term[2] | .//variablelist">
       <xsl:text>
 ++++
 </xsl:text>
@@ -729,6 +729,7 @@ ____
   <xsl:text>+</xsl:text><xsl:value-of select="util:carriage-returns(1)"/>
 </xsl:if>
 <xsl:call-template name="process-id"/>
+<xsl:text>&#10;</xsl:text>
 <xsl:text>.</xsl:text><xsl:apply-templates select="title"/>
 image::<xsl:value-of select="mediaobject/imageobject[@role='web']/imagedata/@fileref"/>[]
 <xsl:choose>
@@ -740,6 +741,7 @@ image::<xsl:value-of select="mediaobject/imageobject[@role='web']/imagedata/@fil
 <xsl:template match="informalfigure">
 <xsl:value-of select="util:carriage-returns(1)"/>
 <xsl:call-template name="process-id"/>
+<xsl:text>&#10;</xsl:text>
 image::<xsl:value-of select="mediaobject/imageobject[@role='web']/imagedata/@fileref"/>[]
 <xsl:value-of select="util:carriage-returns(1)"/>
 </xsl:template>
@@ -1261,7 +1263,7 @@ pass:[<xsl:copy-of select="."/>]
   <xsl:if test="@id">
     <xsl:text xml:space="preserve">[[</xsl:text>
     <xsl:value-of select="@id"/>
-    <xsl:text xml:space="preserve">]]&#10;</xsl:text>
+    <xsl:text xml:space="preserve">]]</xsl:text>
   </xsl:if>
 </xsl:template>
 


### PR DESCRIPTION
A small xpath error was causing all variablelists to be converted as passthroughs, instead of just those lists with nested lists/multiple terms.
